### PR TITLE
check if root user is used

### DIFF
--- a/lmn7-appliance
+++ b/lmn7-appliance
@@ -10,6 +10,10 @@ import os
 import sys
 import urllib.request
 
+# check if the user and go on
+if not os.geteuid() == 0:
+    sys.exit('Please start the script as root user.\n You can use the command "sudo -i" to achieve this.')
+
 # help
 def usage(rc):
     print('Downloads and installs linuxmuster-prepare package and initially prepares')


### PR DESCRIPTION
This implements a tiny check: If the user is root? Okay go on, if not exit and display an error. 
This is needed in install's from scratch if you follow the doc's. A non privileged user is'nt able to perform the commands successfully and creates errors.