### PR TITLE
Correct path for pip3

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -24,7 +24,7 @@ case "$1" in
   configure)
     # ensure python3 reconfigure is installed
     echo -n "Checking for python3-reconfigure ... "
-    if /usr/bin/pip3 list | grep ^reconfigure &> /dev/null; then
+    if /usr/local/bin/pip3 list | grep ^reconfigure &> /dev/null; then
       echo "installed."
       exit 0
     else
@@ -32,7 +32,7 @@ case "$1" in
     fi
 
     # install python3 reconfigure
-    /usr/bin/pip3 install reconfigure
+    /usr/local/bin/pip3 install reconfigure
 
   ;;
 


### PR DESCRIPTION
Install of `linuxmuster-prepare 0.7.6-0ubuntu0` fails because of wrong path of `pip3` : 

```
Checking for python3-reconfigure ... /var/lib/dpkg/info/linuxmuster-prepare.postinst: line 27: /usr/bin/pip3: No such file or directory
 not installed.
/var/lib/dpkg/info/linuxmuster-prepare.postinst: line 35: /usr/bin/pip3: No such file or directory
```

It would be better to use `/usr/bin/python3 -m pip list`, but `/usr/local/bin/pip3 list` should solve it.

Arnaud