### PR TITLE
Gateway4 deprecated

### DIFF
--- a/share/templates/01-netcfg.yaml
+++ b/share/templates/01-netcfg.yaml
@@ -11,10 +11,12 @@ network:
   version: 2
   ethernets:
     @@iface@@:
-      dhcp4: no
-      dhcp6: no
+      dhcp4: false
+      dhcp6: false
       addresses: [@@hostip@@/@@bitmask@@]
-      gateway4: @@gateway@@
+      routes: 
+       - to: default
+         via: @@gateway@@
       nameservers:
         addresses: [@@serverip@@,@@firewallip@@]
         @@dnssearch@@


### PR DESCRIPTION
Property gateway4 is deprecated in 22.04 (please see https://netplan.readthedocs.io/en/stable/netplan-yaml/).
I also moved dhcp4 and dhcp6 to booleans.